### PR TITLE
Reverted floating header as it covers the team pop up

### DIFF
--- a/styles/components/Header.module.css
+++ b/styles/components/Header.module.css
@@ -8,13 +8,10 @@
     align-items: center;
     height: 130px;
     width: 100%;
-    /* Added styles for floating header */
-    position: fixed;
     background-color:#061E33;
-    left: 0; /* Position at the left of the viewport */
     z-index: 20;  /* Ensure it stays on top of other elements */
-    margin-top: 0; /* Remove top margin as it's now fixed */
-    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1); /* Optional: Add a subtle shadow */
+    margin-top: 10px;
+    margin-bottom: 30px;
 }
   
 

--- a/styles/components/Layout.module.css
+++ b/styles/components/Layout.module.css
@@ -12,7 +12,7 @@
 }
 
 .pageContent {
-    margin-top: 150px; /* Adjust the value if your header height changes */
+    margin-top: 0; /* Adjust the value if your header height changes */
     width: 97%;
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
As stated in the title, the floating header can cover the team pop up for certain types of screen size.
So for now, it is better to remove it and then try to implement it in a new way.